### PR TITLE
Update requirements/base.txt for

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,8 +9,8 @@ djangorestframework-expiring-authtoken==0.1.1
 pytz==2015.7
 python-dateutil==2.5.3
 jsonfield==1.0.3
-django-controlcenter===0.2.6
-
+django-controlcenter==0.2.6
+django-pkgconf==0.3.0
 
 # Configuration
 django-environ==0.4.1


### PR DESCRIPTION
When running trying to migrate via `docker-compose run django python manage.py migrate`, I was consistently getting an error:

```
Traceback (most recent call last):
  File "manage.py", line 23, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 338, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 312, in execute
    django.setup()
  File "/usr/local/lib/python2.7/site-packages/django/__init__.py", line 18, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/usr/local/lib/python2.7/site-packages/django/apps/registry.py", line 85, in populate
    app_config = AppConfig.create(entry)
  File "/usr/local/lib/python2.7/site-packages/django/apps/config.py", line 86, in create
    module = import_module(entry)
  File "/usr/local/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/usr/local/lib/python2.7/site-packages/controlcenter/__init__.py", line 1, in <module>
    from .dashboards import Dashboard  # NOQA
  File "/usr/local/lib/python2.7/site-packages/controlcenter/dashboards.py", line 10, in <module>
    from . import app_settings
  File "/usr/local/lib/python2.7/site-packages/controlcenter/app_settings.py", line 1, in <module>
    from pkgconf import Conf
  File "/usr/local/lib/python2.7/site-packages/pkgconf/__init__.py", line 44
    class Conf(metaclass=ConfMeta):
                        ^
SyntaxError: invalid syntax
```

I found this patch via https://stackoverflow.com/a/63620490/186818

> While the `base.txt` requirements did not have the package at all, it was still installed (and used) through other packages and it installed version 0.4.0 which does not support Python 2.7.

Changes to `base.txt`:
- Removed an extra `=` in `django-controlcenter===0.2.6`
- Added the package `django-pkgconf==0.3.0` as that was what it was referring in the error.